### PR TITLE
Fix for floating point derived errors

### DIFF
--- a/size_constrained_clustering/da.py
+++ b/size_constrained_clustering/da.py
@@ -32,7 +32,7 @@ class DeterministicAnnealing(base.Base):
         '''
         super(DeterministicAnnealing, self).__init__(n_clusters, max_iters, distance_func)
         self.lamb = distribution
-        assert np.sum(distribution) == 1 
+        assert round(np.sum(distribution),10) == 1 
         assert len(distribution) == n_clusters
         assert isinstance(T, list) or T is None
 


### PR DESCRIPTION
E.g distribution [0.4,0.3,0.2,0.1] used to fail because it results in 0.9999999 instead of 1.

Adding rounding to prevent problems